### PR TITLE
Added SQS capability

### DIFF
--- a/processor_test.go
+++ b/processor_test.go
@@ -1,0 +1,115 @@
+package lambda
+
+import (
+	"context"
+	"github.com/aws/aws-lambda-go/events"
+	"testing"
+)
+
+func TestStart_DeterminesSQSInvocation(t *testing.T) {
+	ml := MockLambda{api: func(h func(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error)) Response {
+		t.Errorf("incorrect invocation")
+		t.Fail()
+		return Response{}
+	}, request: func(h func(request events.APIGatewayCustomAuthorizerRequestTypeRequest) (events.APIGatewayCustomAuthorizerResponse, error)) Response {
+		t.Errorf("incorrect invocation")
+		t.Fail()
+		return Response{}
+	}, token: func(h func(request events.APIGatewayCustomAuthorizerRequest) (events.APIGatewayCustomAuthorizerResponse, error)) Response {
+		t.Errorf("incorrect invocation")
+		t.Fail()
+		return Response{}
+	}, sqs: func(h func(ctx context.Context, request events.SQSEvent) error) Response {
+		return Response{}
+	}}
+
+	err := ml.start(func(ctx context.Context, request events.SQSEvent) error {
+		return nil
+	})
+
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+}
+
+func TestStart_DeterminesAPIInvocation(t *testing.T) {
+	ml := MockLambda{api: func(h func(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error)) Response {
+		return Response{}
+	}, request: func(h func(request events.APIGatewayCustomAuthorizerRequestTypeRequest) (events.APIGatewayCustomAuthorizerResponse, error)) Response {
+		t.Errorf("incorrect invocation")
+		t.Fail()
+		return Response{}
+	}, token: func(h func(request events.APIGatewayCustomAuthorizerRequest) (events.APIGatewayCustomAuthorizerResponse, error)) Response {
+		t.Errorf("incorrect invocation")
+		t.Fail()
+		return Response{}
+	}, sqs: func(h func(ctx context.Context, request events.SQSEvent) error) Response {
+		t.Errorf("incorrect invocation")
+		t.Fail()
+		return Response{}
+	}}
+
+	err := ml.start(func(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+		return events.APIGatewayProxyResponse{}, nil
+	})
+
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+}
+
+func TestStart_DeterminesRequestInvocation(t *testing.T) {
+	ml := MockLambda{api: func(h func(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error)) Response {
+		t.Errorf("incorrect invocation")
+		t.Fail()
+		return Response{}
+	}, request: func(h func(request events.APIGatewayCustomAuthorizerRequestTypeRequest) (events.APIGatewayCustomAuthorizerResponse, error)) Response {
+		return Response{}
+	}, token: func(h func(request events.APIGatewayCustomAuthorizerRequest) (events.APIGatewayCustomAuthorizerResponse, error)) Response {
+		t.Errorf("incorrect invocation")
+		t.Fail()
+		return Response{}
+	}, sqs: func(h func(ctx context.Context, request events.SQSEvent) error) Response {
+		t.Errorf("incorrect invocation")
+		t.Fail()
+		return Response{}
+	}}
+
+	err := ml.start(func(request events.APIGatewayCustomAuthorizerRequestTypeRequest) (events.APIGatewayCustomAuthorizerResponse, error) {
+		return events.APIGatewayCustomAuthorizerResponse{}, nil
+	})
+
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+}
+
+func TestStart_DeterminesTokenInvocation(t *testing.T) {
+	ml := MockLambda{api: func(h func(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error)) Response {
+		t.Errorf("incorrect invocation")
+		t.Fail()
+		return Response{}
+	}, request: func(h func(request events.APIGatewayCustomAuthorizerRequestTypeRequest) (events.APIGatewayCustomAuthorizerResponse, error)) Response {
+		t.Errorf("incorrect invocation")
+		t.Fail()
+		return Response{}
+	}, token: func(h func(request events.APIGatewayCustomAuthorizerRequest) (events.APIGatewayCustomAuthorizerResponse, error)) Response {
+		return Response{}
+	}, sqs: func(h func(ctx context.Context, request events.SQSEvent) error) Response {
+		t.Errorf("incorrect invocation")
+		t.Fail()
+		return Response{}
+	}}
+
+	err := ml.start(func(request events.APIGatewayCustomAuthorizerRequest) (events.APIGatewayCustomAuthorizerResponse, error) {
+		return events.APIGatewayCustomAuthorizerResponse{}, nil
+	})
+
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+}

--- a/sqs.go
+++ b/sqs.go
@@ -1,0 +1,43 @@
+package lambda
+
+import (
+	"context"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambdacontext"
+)
+
+func sqs(h func(ctx context.Context, request events.SQSEvent) error) Response {
+	response := Response{
+		Payload: Payload{},
+	}
+
+	event := events.SQSEvent{}
+	err := decode(os.Getenv("LAMBDA_EVENT"), &event)
+	if err != nil {
+		response.Payload.Error = err.Error()
+		return response
+	}
+
+	ctxArgs := map[string]interface{}{}
+	err = decode(os.Getenv("LAMBDA_CONTEXT"), &ctxArgs)
+	if err != nil {
+		response.Payload.Error = err.Error()
+		return response
+	}
+
+	ctx := lambdacontext.NewContext(context.Background(), &lambdacontext.LambdaContext{
+		AwsRequestID:       ctxArgs["awsRequestId"].(string),
+		InvokedFunctionArn: ctxArgs["invokedFunctionArn"].(string),
+	})
+
+	err = h(ctx, event)
+	if err != nil {
+		response.Payload.Error = err.Error()
+		return response
+	}
+
+	response.Payload.Success = err != nil
+	return response
+}


### PR DESCRIPTION
# Summary
Added SQS function invocation capability.

Due to the serverless-offline-sqs package not setting context on if the function we are invoking is an SQS function I shifted this package to using reflection. It will now look at the targets function parameters to determine the invocation mode and the object type to decode the lambda context event to.

https://github.com/CoorpAcademy/serverless-plugins/tree/master/packages/serverless-offline-sqs